### PR TITLE
Missing semicolon in schema.sql

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -265,7 +265,7 @@ CREATE TABLE zacks.earnings_calendar
         REFERENCES nasdaq.symbol (act_symbol) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE NO ACTION
-)
+);
 
 CREATE OR REPLACE FUNCTION zacks.to_integer_rank(
 	rank zacks.rank)


### PR DESCRIPTION
Added a missing semicolon to the schema.sql file for the `zacks.earnings_calendar` table .